### PR TITLE
IPv6 use interface when sending to link-local dest

### DIFF
--- a/src/ipv6.cpp
+++ b/src/ipv6.cpp
@@ -366,11 +366,14 @@ void IPv6::write_serialization(uint8_t* buffer, uint32_t total_sz) {
 }
 
 #ifndef BSD
-void IPv6::send(PacketSender& sender, const NetworkInterface &) {
+void IPv6::send(PacketSender& sender, const NetworkInterface & interface) {
     sockaddr_in6 link_addr;
     const PacketSender::SocketType type = PacketSender::IPV6_SOCKET;
     link_addr.sin6_family = AF_INET6;
     link_addr.sin6_port = 0;
+    if (IPv6Address(header_.dst_addr).is_local_unicast()) {
+        link_addr.sin6_scope_id = interface.id();
+    }
     memcpy((uint8_t*)&link_addr.sin6_addr, header_.dst_addr, address_type::address_size);
     sender.send_l3(*this, (struct sockaddr*)&link_addr, sizeof(link_addr), type);
 }


### PR DESCRIPTION
In order to ping IPv6 link-local addresses we need to specific the interface to use.

More info here. https://fnetdci.atlassian.net/wiki/spaces/HEAR/pages/2436333569/IPv6+Link-local+Ping+Issue

Note this potentially go against what the author intentions. http://libtins.github.io/docs/latest/d3/dea/classTins_1_1PacketSender.html
